### PR TITLE
add Dadata and DadataAsync in __init__.py

### DIFF
--- a/dadata/__init__.py
+++ b/dadata/__init__.py
@@ -6,4 +6,4 @@ from dadata.sync import DadataClient as Dadata  # noqa
 from dadata.asynchr import DadataClient as DadataAsync  # noqa
 
 __version__ = "21.10.1"
-__all__ = []  # type: ignore
+__all__ = [Dadata, DadataAsync]  # type: ignore


### PR DESCRIPTION
Added **Dadata** and **DadataAsync** in `__init__.py` because pycharm swore at it
![image](https://user-images.githubusercontent.com/75297871/153583648-5cee6a18-0dcd-4130-8fdc-48948ecc2048.png)